### PR TITLE
Reimplement ChainIndex::updateFromFilesystem to prevent segfaults

### DIFF
--- a/src/parser/chain_index.cpp
+++ b/src/parser/chain_index.cpp
@@ -70,7 +70,7 @@ public:
             *val = static_cast<uint32_t>(part);
             return true;
         } else if (v == 0xFE) {
-            return readNext(&val);
+            return readNext(val);
         } else {
             uint64_t part;
             if (!readNext(&part)) {


### PR DESCRIPTION
The problem was that original code could potentially read beyond memory-mapped file range and this would segfault in rare cases when memory mapped range would be aligned with memory page boundary.

Specifically the problem was in blk00682.dat of bitcoin blockchain at this line:
https://github.com/citp/BlockSci/blob/393c6f4a31170c05210d6da025f8529657d976f5/src/parser/chain_index.cpp#L98

I took this opportunity and added some diagnostic error reporting as well.