### PR TITLE
Fix MapReduce

### DIFF
--- a/Notebooks/blocksci/__init__.py
+++ b/Notebooks/blocksci/__init__.py
@@ -48,14 +48,14 @@ def mapreduce_blocks(chain, mapFunc, reduceFunc, init, start=None, end=None, cpu
     """
     def mapRangeFunc(blocks):
         return reduce(reduceFunc, (mapFunc(block) for block in blocks), init)
-    return mapreduce_block_ranges(chain, mapRangeFunc, start, end, reduceFunc, init, cpu_count)
+    return mapreduce_block_ranges(chain, mapRangeFunc, reduceFunc, init, start, end, cpu_count)
 
 def mapreduce_txes(chain, mapFunc, reduceFunc, init,  start=None, end=None, cpu_count=psutil.cpu_count()):
     """Initialized multithreaded map reduce function over a stream of transactions
     """
     def mapRangeFunc(blocks):
         return reduce(reduceFunc, (mapFunc(tx) for block in blocks for tx in block))
-    return mapreduce_block_ranges(chain, mapRangeFunc, start, end, reduceFunc, init, cpu_count)
+    return mapreduce_block_ranges(chain, mapRangeFunc, reduceFunc, init, start, end, cpu_count)
 
 
 def map_blocks(self, blockFunc, start = None, end = None, cpu_count=psutil.cpu_count()):

--- a/Notebooks/blocksci/__init__.py
+++ b/Notebooks/blocksci/__init__.py
@@ -32,7 +32,7 @@ def mapreduce_block_ranges(chain, mapFunc, reduceFunc, init,  start=None, end=No
         end = blocks[-1].height
 
     if cpu_count == 1:
-        return reduce(reduceFunc, (mapFunc(block) for block in chain[start:end]))
+        return mapFunc(chain[start:end])
 
     segments = chain.segment(start, end, cpu_count)
     with Pool(cpu_count - 1) as p:


### PR DESCRIPTION
1) In two calls of _mapreduce_block_ranges_ parameters got mixed up.
2) For the single-core version of _mapreduce_block_ranges_, the block input cannot yet be reduced as another call to a map function follows. This can be reproduced by adding the parameter *cpu_count=1* to the _map_blocks_ call when **Measuring different types of address use** in the demo notebook.

```
%time net_coins_per_block = chain.map_blocks(lambda block: block.net_address_type_value(), cpu_count=1)
```