### PR TITLE
accelerate_totalOutWithoutSelfChurn

### DIFF
--- a/blockscipy/src/cluster/cluster/cluster_py.cpp
+++ b/blockscipy/src/cluster/cluster/cluster_py.cpp
@@ -27,7 +27,7 @@ int64_t totalOutWithoutSelfChurn(const blocksci::Block &block, blocksci::Cluster
         std::set<uint32_t> inputClusters;
         RANGES_FOR(auto input, tx.inputs()) {
             auto cluster = manager.getCluster(input.getAddress());
-            if (cluster.getSize() < 30000) {
+            if (cluster.getTypeEquivSize() < 30000) {
                 inputClusters.insert(cluster.clusterNum);
             }
         }


### PR DESCRIPTION
Hi Harry, this is zaczw who wrote https://github.com/citp/BlockSci/issues/111. The only change I made was the one you suggested: change cluster.getSize() to cluster.getTypeEquivSize(). Let me know if there was a problem with how I did it.

Thanks!
Zachry