### PR TITLE
fix: update required cmake version to 3.8.2

### DIFF
--- a/blockscipy/CMakeLists.txt
+++ b/blockscipy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8.2)
 project(blockscipy)
 
 set (CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
On line 4, the C++ standard is set to 17. This value is only supported
from CMake 3.8.2, as can be seen here:

https://cmake.org/cmake/help/v3.8/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD

Currently, this only leads to a very silent info message, and its value
is ignored, possibly leading to failed installations. This way it is
made explicit.