### PR TITLE
Add NoChange heuristic to disable change address clustering

### DIFF
--- a/blockscipy/src/heuristics_py.cpp
+++ b/blockscipy/src/heuristics_py.cpp
@@ -99,5 +99,10 @@ void init_heuristics(py::module &m) {
         "Return a ChangeHeuristic object implementing the legacy heuristic: The original change address heuristic used in blocksci consisting of the intersection of the optimal change heuristic and the client address behavior heuristic")
     .def("legacy", [](const Transaction &tx) { return LegacyChange{}(tx); }, py::arg("tx"),
         "Apply the legacy heuristic to a transaction and return the set outputs that could be the change address.")
+
+    .def("none", []() { return ChangeHeuristic{NoChange{}}; },
+         "Return a ChangeHeuristic object implementing no change heuristic (effectively disabling it).")
+    .def("none", [](const Transaction &tx) { return NoChange{}(tx); }, py::arg("tx"),
+         "Apply the no change heuristic to a transaction and return no outputs.")
     ;
 }

--- a/docs/reference/clustering/cluster_manager.rst
+++ b/docs/reference/clustering/cluster_manager.rst
@@ -1,5 +1,25 @@
 ClusterManager
 ====================================
 
+The ClusterManager can be used to create new or load existing clusterings.
+The following example will create a new clustering using the legacy heuristic.
+To overwrite an existing clustering, set ``should_overwrite=True``.
+
+..  code-block:: python
+
+    heuristic = blocksci.heuristics.change.legacy()
+    cm = blocksci.cluster.ClusterManager.create_clustering(cluster_directory, chain, heuristic)
+
+Instead of creating a new clustering, you can also load a previously created clustering.
+
+..  code-block:: python
+
+    cm = blocksci.cluster.ClusterManager(cluster_directory, chain)
+
+Then, you can retrieve all clusters using :py:meth:`~blocksci.cluster.ClusterManager.clusters` or retrieve a specific cluster based on an address using :py:meth:`~blocksci.cluster.ClusterManager.cluster_with_address`.
+
+Various different change address detection heuristics are available in :py:mod:`blocksci.heuristics.change`. If you don't want to include change addresses in your clustering, choose :py:func:`blocksci.heuristics.change.none` as your heuristic to disable change address detection.
+
+
 .. autoclass:: blocksci.cluster.ClusterManager
    :members:

--- a/docs/reference/clustering/clustering.rst
+++ b/docs/reference/clustering/clustering.rst
@@ -3,7 +3,7 @@ Clustering
 
 .. automodule:: blocksci.cluster
 
-The BlockSci clustering module provides users with the ability to apply heuristic based clustering techniques to a Blockchain instance. The cluster_manager is the main entrace into this module. Using it you can open an already produced clustering or create a new clustering based on a change address heuristic of your choice.
+The BlockSci clustering module provides users with the ability to apply heuristic based clustering techniques to a Blockchain instance. The :py:class:`ClusterManager` is the main entrace into this module. Using it you can open an already produced clustering or create a new clustering based on a change address heuristic of your choice.
 
 BlockSci's clustering module is a simple effort to explore heuristic based clustering techniques. Users should not assume that it's results will be correct in practice. Providing a more accurate clustering mechanism is an ongoing research project.
 

--- a/include/blocksci/heuristics/change_address.hpp
+++ b/include/blocksci/heuristics/change_address.hpp
@@ -17,8 +17,8 @@
 
 #include <unordered_set>
 
-#define CHANGE_ADDRESS_TYPE_LIST VAL(PeelingChain), VAL(PowerOfTen), VAL(OptimalChange), VAL(AddressType), VAL(Locktime), VAL(AddressReuse), VAL(ClientChangeAddressBehavior), VAL(Legacy)
-#define CHANGE_ADDRESS_TYPE_SET VAL(PeelingChain) VAL(PowerOfTen) VAL(OptimalChange) VAL(AddressType) VAL(Locktime), VAL(AddressReuse), VAL(ClientChangeAddressBehavior) VAL(Legacy)
+#define CHANGE_ADDRESS_TYPE_LIST VAL(PeelingChain), VAL(PowerOfTen), VAL(OptimalChange), VAL(AddressType), VAL(Locktime), VAL(AddressReuse), VAL(ClientChangeAddressBehavior), VAL(Legacy), VAL(None)
+#define CHANGE_ADDRESS_TYPE_SET VAL(PeelingChain) VAL(PowerOfTen) VAL(OptimalChange) VAL(AddressType) VAL(Locktime), VAL(AddressReuse), VAL(ClientChangeAddressBehavior) VAL(Legacy), VAL(None)
 namespace blocksci {
 namespace heuristics {
     
@@ -35,7 +35,7 @@ namespace heuristics {
         #undef VAL
         };
         #define VAL(x) Enum::x
-        static constexpr std::array<Enum, 8> all = {{CHANGE_ADDRESS_TYPE_LIST}};
+        static constexpr std::array<Enum, 9> all = {{CHANGE_ADDRESS_TYPE_LIST}};
         #undef VAL
         static constexpr size_t size = all.size();
     };
@@ -67,6 +67,7 @@ namespace heuristics {
     using AddressReuseChange = ChangeHeuristicImpl<ChangeType::AddressReuse>;
     using ClientChangeAddressBehaviorChange = ChangeHeuristicImpl<ChangeType::ClientChangeAddressBehavior>;
     using LegacyChange = ChangeHeuristicImpl<ChangeType::Legacy>;
+    using NoChange = ChangeHeuristicImpl<ChangeType::None>;
         
     struct BLOCKSCI_EXPORT ChangeHeuristic {
         
@@ -154,6 +155,8 @@ namespace heuristics {
     
     std::unordered_set<Output> BLOCKSCI_EXPORT changeByLegacyHeuristic(const Transaction &tx);
     ranges::optional<Output> BLOCKSCI_EXPORT uniqueChangeByLegacyHeuristic(const Transaction &tx);
+    
+    std::unordered_set<Output> BLOCKSCI_EXPORT noChange(const Transaction &tx);
 }}
 
 #endif /* change_address_hpp */

--- a/src/heuristics/change_address.cpp
+++ b/src/heuristics/change_address.cpp
@@ -45,6 +45,15 @@ namespace blocksci { namespace heuristics {
         return filtered_candidates;
     }
     
+    // No change address detection
+    // This function mostly exists to ensure a consistent API.
+    // The set it returns will never contain more than one output.
+    template<>
+    std::unordered_set<Output> ChangeHeuristicImpl<ChangeType::None>::operator()(const Transaction &tx) const {
+        std::unordered_set<Output> candidates;
+        return candidates;
+    }
+    
     // Peeling chains have one input and two outputs
     bool looksLikePeelingChain(const Transaction &tx) {
         return (tx.outputCount() == 2 && tx.inputCount() == 1);


### PR DESCRIPTION
Adds a NoChange / `blocksci.heuristics.change.none()` heuristic that effectively disables change address clustering. Also adds documentation for the `ClusterManager`, explaining its use and how to disable change address clustering.