### PR TITLE
Add option to disable CoinJoin detection during clustering

### DIFF
--- a/blockscipy/src/cluster/cluster/cluster_py.cpp
+++ b/blockscipy/src/cluster/cluster/cluster_py.cpp
@@ -50,13 +50,13 @@ void init_cluster_manager(pybind11::module &s) {
     .def(py::init([](std::string arg, blocksci::Blockchain &chain) {
        return ClusterManager(arg, chain.getAccess());
     }))
-    .def_static("create_clustering", [](const std::string &location, Blockchain &chain, const heuristics::ChangeHeuristic &heuristic, bool shouldOverwrite) {
+    .def_static("create_clustering", [](const std::string &location, Blockchain &chain, const heuristics::ChangeHeuristic &heuristic, bool shouldOverwrite, bool ignoreCoinjoin) {
         py::scoped_ostream_redirect stream(
                                            std::cout,
                                            py::module::import("sys").attr("stdout")
                                            );
-        return ClusterManager::createClustering(chain, heuristic, location, shouldOverwrite);
-    }, py::arg("location"), py::arg("chain"), py::arg("heuristic") = heuristics::ChangeHeuristic{heuristics::LegacyChange{}}, py::arg("should_overwrite") = false)
+        return ClusterManager::createClustering(chain, heuristic, location, shouldOverwrite, ignoreCoinjoin);
+    }, py::arg("location"), py::arg("chain"), py::arg("heuristic") = heuristics::ChangeHeuristic{heuristics::LegacyChange{}}, py::arg("should_overwrite") = false, py::arg("ignore_coinjoin") = true)
     .def("cluster_with_address", [](const ClusterManager &cm, const Address &address) -> Cluster {
        return cm.getCluster(address);
     }, py::arg("address"), "Return the cluster containing the given address")

--- a/include/blocksci/cluster/cluster_manager.hpp
+++ b/include/blocksci/cluster/cluster_manager.hpp
@@ -30,7 +30,7 @@ namespace blocksci {
     public:
         ClusterManager(const std::string &baseDirectory, DataAccess &access);
         
-        static ClusterManager createClustering(Blockchain &chain, const heuristics::ChangeHeuristic &heuristic, const std::string &outputPath, bool overwrite = false);
+        static ClusterManager createClustering(Blockchain &chain, const heuristics::ChangeHeuristic &heuristic, const std::string &outputPath, bool overwrite = false, bool ignoreCoinjoin = true);
         
         Cluster getCluster(const Address &address) const;
         


### PR DESCRIPTION
Allows to disable CoinJoin detection during clustering, which would be useful for cryptocurrencies where CJ is not common.