### PR TITLE
Create PID file to prevent multiple parser instances from running simultaneously

### DIFF
--- a/src/internal/data_configuration.hpp
+++ b/src/internal/data_configuration.hpp
@@ -64,6 +64,10 @@ namespace blocksci {
             return chainConfig.dataDirectory/"hashIndex";
         }
         
+        filesystem::path pidFilePath() const {
+            return chainConfig.dataDirectory/"blocksci_parser.pid";
+        }
+        
         bool operator==(const DataConfiguration &other) const {
             return chainConfig.dataDirectory == other.chainConfig.dataDirectory;
         }


### PR DESCRIPTION
Attempts to create a `blocksci_parser.pid` file in the data directory when starting the parser and aborts if one already exists. Should fix #211. (File is not created for `blocksci_parser help` or `blocksci_parser create_config`).