### PR TITLE
fix: update range-v3 submodule to 0.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/mpark/variant.git
 [submodule "libs/range-v3"]
 	path = external/range-v3
-	url = https://github.com/hkalodner/range-v3.git
+	url = https://github.com/maltemoeser/range-v3.git
 [submodule "Notebooks/blocksci/Blockchain-Known-Pools"]
 	path = blockscipy/blocksci/Blockchain-Known-Pools
 	url = https://github.com/blockchain/Blockchain-Known-Pools


### PR DESCRIPTION
Updates the range-v3 submodule to version 0.4.0 with our patch applied.

Relevant commit is here: https://github.com/maltemoeser/range-v3/commit/78bbc97a835ed5e2a2daa9766988c25772cddf60

Fixes: #261

To use this, you'll need to run `git submodule sync` followed by `git submodule update` since the URL for the submodule has changed.