### PR TITLE
fix: use correct nVersionBytes for address lookup

### DIFF
--- a/src/address/address.cpp
+++ b/src/address/address.cpp
@@ -253,7 +253,8 @@ namespace blocksci {
             }
             return ranges::nullopt;
         }
-        CBitcoinAddress address{addressString};
+        unsigned int nVersionBytes = access.config.chainConfig.pubkeyPrefix.size();
+        CBitcoinAddress address{addressString, nVersionBytes};
         uint160 hash;
         blocksci::AddressType::Enum type;
         std::tie(hash, type) = address.Get(access.config.chainConfig);

--- a/src/scripts/bitcoin_base58.cpp
+++ b/src/scripts/bitcoin_base58.cpp
@@ -181,9 +181,9 @@ namespace blocksci {
         return true;
     }
 
-    bool CBase58Data::SetString(const std::string& str)
+    bool CBase58Data::SetString(const std::string& str, unsigned int nVersionBytes)
     {
-        return SetString(str.c_str());
+        return SetString(str.c_str(), nVersionBytes);
     }
 
     std::string CBase58Data::ToString() const

--- a/src/scripts/bitcoin_base58.hpp
+++ b/src/scripts/bitcoin_base58.hpp
@@ -85,7 +85,7 @@ namespace blocksci {
         
     public:
         bool SetString(const char* psz, unsigned int nVersionBytes = 1);
-        bool SetString(const std::string& str);
+        bool SetString(const std::string& str, unsigned int nVersionBytes = 1);
         std::string ToString() const;
         int CompareTo(const CBase58Data& b58) const;
         
@@ -106,7 +106,7 @@ namespace blocksci {
     public:
         CBitcoinAddress(const uint160 &dest, AddressType::Enum type, const ChainConfiguration &config);
         CBitcoinAddress(const uint160 &dest, const std::vector<unsigned char>& version);
-        CBitcoinAddress(const std::string& strAddress) { SetString(strAddress); }
+        CBitcoinAddress(const std::string& strAddress, unsigned int nVersionBytes) { SetString(strAddress, nVersionBytes); }
         CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
         
         std::pair<uint160, AddressType::Enum> Get(const ChainConfiguration &config) const;


### PR DESCRIPTION
Previously a default of 1 was used for nVersionBytes, resulting in addresses not being found when nVersionBytes was > 1 (e.g., for Zcash). Implementation assumes pubkeyPrefix and scriptPrefix have the same length (I'm currently not aware of a counterexample).

Fixes: https://github.com/citp/BlockSci/issues/246