### PR TITLE
feat: unix timestamp for mempool records

### DIFF
--- a/blockscipy/src/chain/block/block_proxy_py.cpp
+++ b/blockscipy/src/chain/block/block_proxy_py.cpp
@@ -38,6 +38,7 @@ struct AddBlockMethods {
         func(property_tag, "timestamp", &Block::timestamp, "Creation timestamp specified in block header");
         func(property_tag, "time", &Block::getTime, "Datetime object created from creation timestamp");
         func(property_tag, "time_seen", &Block::getTimeSeen, "If recorded by the mempool recorder, the time that this block was first seen by your node");
+        func(property_tag, "timestamp_seen", &Block::getTimestampSeen, "If recorded by the mempool recorder, the timestamp that this block was first seen by your node");
         func(property_tag, "bits", &Block::bits, "Difficulty threshold specified in block header");
         func(property_tag, "nonce", &Block::nonce, "Nonce specified in block header");
         func(property_tag, "height", &Block::height, "Height of the block in the blockchain");

--- a/blockscipy/src/chain/tx/tx_proxy_py.cpp
+++ b/blockscipy/src/chain/tx/tx_proxy_py.cpp
@@ -42,6 +42,7 @@ struct AddTransactionMethods {
         }, "The time that the block containing this transaction arrived");
         func(property_tag, "observed_in_mempool", &Transaction::observedInMempool, "Returns whether this transaction was seen in the mempool by the recorder");
         func(property_tag, "time_seen", &Transaction::getTimeSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
+        func(property_tag, "timestamp_seen", &Transaction::getTimestampSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
         func(property_tag, "block", &Transaction::block, "The block that this transaction was in");
         func(property_tag, "index", +[](const Transaction &tx) { return tx.txNum; }, "The internal index of this transaction");
         func(property_tag, "hash", &Transaction::getHash, "The 256-bit hash of this transaction");

--- a/include/blocksci/chain/block.hpp
+++ b/include/blocksci/chain/block.hpp
@@ -58,6 +58,7 @@ namespace blocksci {
         
         // Mempool data
         ranges::optional<std::chrono::system_clock::time_point> getTimeSeen() const;
+        ranges::optional<uint32_t> getTimestampSeen() const;
         
         uint32_t bits() const {
             return rawBlock->bits;

--- a/include/blocksci/chain/transaction.hpp
+++ b/include/blocksci/chain/transaction.hpp
@@ -81,6 +81,7 @@ namespace blocksci {
         
         // Mempool data access
         ranges::optional<std::chrono::system_clock::time_point> getTimeSeen() const;
+        ranges::optional<uint32_t> getTimestampSeen() const;
         bool observedInMempool() const;
         
         std::string toString() const;

--- a/src/chain/block.cpp
+++ b/src/chain/block.cpp
@@ -23,7 +23,16 @@ namespace blocksci {
     Block::Block(BlockHeight blockNum_, DataAccess &access_) : Block(access_.getChain().getBlock(blockNum_), blockNum_, access_) {}
     
     ranges::optional<std::chrono::system_clock::time_point> Block::getTimeSeen() const {
-        return getAccess().getMempoolIndex().getBlockTimestamp(height());
+        return getAccess().getMempoolIndex().getBlockTime(height());
+    }
+
+    ranges::optional<uint32_t> Block::getTimestampSeen() const {
+        auto ts = getAccess().getMempoolIndex().getBlockTimestamp(height());
+        if (ts) {
+            return static_cast<uint32_t>(ts.value());
+        } else {
+            return ranges::nullopt;
+        }
     }
     
     std::vector<unsigned char> Block::getCoinbase() const {

--- a/src/chain/transaction.cpp
+++ b/src/chain/transaction.cpp
@@ -77,7 +77,16 @@ namespace blocksci {
     }
     
     ranges::optional<std::chrono::system_clock::time_point> Transaction::getTimeSeen() const {
-        return access->getMempoolIndex().getTxTimestamp(txNum);
+        return access->getMempoolIndex().getTxTime(txNum);
+    }
+
+    ranges::optional<uint32_t> Transaction::getTimestampSeen() const {
+        auto ts = access->getMempoolIndex().getTxTimestamp(txNum);
+        if (ts) {
+            return static_cast<uint32_t>(ts.value());
+        } else {
+            return ranges::nullopt;
+        }
     }
     
     bool Transaction::observedInMempool() const {


### PR DESCRIPTION
Return the unix timestamp for mempool records, useful in combination with the proxy interface or to prevent timezone issues when working with timestamps