### PR TITLE
perf: use normal properties to avoid function calls to proxy objects

### DIFF
--- a/blockscipy/src/chain/block/block_properties_py.hpp
+++ b/blockscipy/src/chain/block/block_properties_py.hpp
@@ -1,0 +1,60 @@
+//
+//  block_properties_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/26/19.
+//
+
+#ifndef block_properties_py_h
+#define block_properties_py_h
+
+#include "method_tags.hpp"
+
+#include <blocksci/chain/block.hpp>
+#include <blocksci/chain/algorithms.hpp>
+
+#include <pybind11/chrono.h>
+#include <pybind11/pytypes.h>
+
+struct AddBlockMethods {
+    template <typename FuncApplication>
+    void operator()(FuncApplication func) {
+        using namespace blocksci;
+        namespace py = pybind11;
+
+        func(property_tag, "next_block", &Block::nextBlock, "Returns the block which follows this one in the chain");
+        func(property_tag, "prev_block", &Block::prevBlock, "Returns the block which comes before this one in the chain");
+        func(property_tag, "hash", &Block::getHash, "Hash of this block");
+        func(property_tag, "version", &Block::version, "Protocol version specified in block header");
+        func(property_tag, "timestamp", &Block::timestamp, "Creation timestamp specified in block header");
+        func(property_tag, "time", &Block::getTime, "Datetime object created from creation timestamp");
+        func(property_tag, "time_seen", &Block::getTimeSeen, "If recorded by the mempool recorder, the time that this block was first seen by your node");
+        func(property_tag, "timestamp_seen", &Block::getTimestampSeen, "If recorded by the mempool recorder, the timestamp that this block was first seen by your node");
+        func(property_tag, "bits", &Block::bits, "Difficulty threshold specified in block header");
+        func(property_tag, "nonce", &Block::nonce, "Nonce specified in block header");
+        func(property_tag, "height", &Block::height, "Height of the block in the blockchain");
+        func(property_tag, "coinbase_param", +[](const Block &block) -> py::bytes {
+            return py::bytes(block.coinbaseParam());
+        }, "Data contained within the coinbase transaction of this block");
+        func(property_tag, "coinbase_tx", &Block::coinbaseTx, "Return the coinbase transaction in this block");
+        func(property_tag, "size_bytes", &Block::totalSize, "Returns the total size of the block in bytes");
+        func(property_tag, "fee", totalFee<Block>, "The sum of the transaction fees contained in this block");
+        func(property_tag, "revenue", +[](const Block &block) -> int64_t {
+            return totalOutputValue(block[0]);
+        }, "Total reward received by the miner of this block");
+        func(property_tag, "base_size", &Block::baseSize, "The size of the non-segwit data in bytes");
+        func(property_tag, "total_size", &Block::totalSize, "The size all block data in bytes");
+        func(property_tag, "virtual_size", &Block::virtualSize, "The weight of the block divided by 4");
+        func(property_tag, "weight", &Block::weight, "Three times the base size plus the total size");
+        func(property_tag, "input_value", totalInputValue<Block &>, "Returns the sum of the value of all of the inputs included in this block");
+        func(property_tag, "output_value", totalOutputValue<Block &>, "Returns the sum of the value of all of the outputs included in this block");
+        func(property_tag, "tx_count", +[](const Block &block) -> int64_t {
+            return block.size();
+        }, "A range of all of the txes in the block");
+        func(property_tag, "input_count", inputCount<Block &>, "Returns total number of inputs included in this block");
+        func(property_tag, "output_count", outputCount<Block &>, "Returns total number of outputs included in this block");
+        ;
+    }
+};
+
+#endif /* block_properties_py_h */

--- a/blockscipy/src/chain/block/block_proxy_py.cpp
+++ b/blockscipy/src/chain/block/block_proxy_py.cpp
@@ -7,20 +7,18 @@
 //
 
 #include "block_proxy_py.hpp"
+#include "block_properties_py.hpp"
 #include "proxy_apply_py.hpp"
 #include "proxy/basic.hpp"
 #include "proxy/equality.hpp"
 #include "proxy/optional.hpp"
 #include "proxy/range.hpp"
 
-#include <blocksci/chain/algorithms.hpp>
-#include <blocksci/cluster/cluster.hpp>
 
-struct AddBlockMethods {
+struct AddBlockProxyMethods {
     template <typename FuncApplication>
     void operator()(FuncApplication func) {
         using namespace blocksci;
-        namespace py = pybind11;
         
         func(property_tag, "txes", +[](const Block &block) -> RawRange<Transaction> {
             return ranges::any_view<blocksci::Transaction, random_access_sized>{block};
@@ -31,37 +29,6 @@ struct AddBlockMethods {
         func(property_tag, "outputs", +[](const Block &block) -> RawIterator<Output> {
             return ranges::any_view<blocksci::Output>{outputs(block)};
         }, "A range of all of the outputs in the block");
-        func(property_tag, "next_block", &Block::nextBlock, "Returns the block which follows this one in the chain");
-        func(property_tag, "prev_block", &Block::prevBlock, "Returns the block which comes before this one in the chain");
-        func(property_tag, "hash", &Block::getHash, "Hash of this block");
-        func(property_tag, "version", &Block::version, "Protocol version specified in block header");
-        func(property_tag, "timestamp", &Block::timestamp, "Creation timestamp specified in block header");
-        func(property_tag, "time", &Block::getTime, "Datetime object created from creation timestamp");
-        func(property_tag, "time_seen", &Block::getTimeSeen, "If recorded by the mempool recorder, the time that this block was first seen by your node");
-        func(property_tag, "timestamp_seen", &Block::getTimestampSeen, "If recorded by the mempool recorder, the timestamp that this block was first seen by your node");
-        func(property_tag, "bits", &Block::bits, "Difficulty threshold specified in block header");
-        func(property_tag, "nonce", &Block::nonce, "Nonce specified in block header");
-        func(property_tag, "height", &Block::height, "Height of the block in the blockchain");
-        func(property_tag, "coinbase_param", +[](const Block &block) -> py::bytes {
-            return py::bytes(block.coinbaseParam());
-        }, "Data contained within the coinbase transaction of this block");
-        func(property_tag, "coinbase_tx", &Block::coinbaseTx, "Return the coinbase transaction in this block");
-        func(property_tag, "size_bytes", &Block::totalSize, "Returns the total size of the block in bytes");
-        func(property_tag, "fee", totalFee<Block>, "The sum of the transaction fees contained in this block");
-        func(property_tag, "revenue", +[](const Block &block) -> int64_t {
-            return totalOutputValue(block[0]);
-        }, "Total reward received by the miner of this block");
-        func(property_tag, "base_size", &Block::baseSize, "The size of the non-segwit data in bytes");
-        func(property_tag, "total_size", &Block::totalSize, "The size all block data in bytes");
-        func(property_tag, "virtual_size", &Block::virtualSize, "The weight of the block divided by 4");
-        func(property_tag, "weight", &Block::weight, "Three times the base size plus the total size");
-        func(property_tag, "input_value", totalInputValue<Block &>, "Returns the sum of the value of all of the inputs included in this block");
-        func(property_tag, "output_value", totalOutputValue<Block &>, "Returns the sum of the value of all of the outputs included in this block");
-        func(property_tag, "tx_count", +[](const Block &block) -> int64_t {
-            return block.size();
-        }, "A range of all of the txes in the block");
-        func(property_tag, "input_count", inputCount<Block &>, "Returns total number of inputs included in this block");
-        func(property_tag, "output_count", outputCount<Block &>, "Returns total number of outputs included in this block");
         ;
     }
 };
@@ -72,5 +39,6 @@ void addBlockProxyMethods(AllProxyClasses<blocksci::Block> &cls) {
 	addProxyOptionalMethods(cls.optional);
 
     applyMethodsToProxy(cls.base, AddBlockMethods{});
+    applyMethodsToProxy(cls.base, AddBlockProxyMethods{});
     addProxyEqualityMethods(cls.base);
 }

--- a/blockscipy/src/chain/block/block_py.cpp
+++ b/blockscipy/src/chain/block/block_py.cpp
@@ -7,11 +7,13 @@
 //
 
 #include "block_py.hpp"
+#include "block_properties_py.hpp"
 #include "caster_py.hpp"
 #include "ranges_py.hpp"
 
+#include "self_apply_py.hpp"
+
 #include <blocksci/chain/access.hpp>
-#include <blocksci/chain/block.hpp>
 
 #include <pybind11/operators.h>
 
@@ -64,6 +66,9 @@ void init_uint160(py::class_<uint160> &cl) {
 
 void init_block(py::class_<Block> &cl) {
     // addGenericRangeMethods(cl);
+
+    applyMethodsToSelf(cl, AddBlockMethods{});
+
     cl
     .def("__repr__", &Block::toString)
     .def(py::self == py::self)
@@ -81,7 +86,6 @@ void init_block(py::class_<Block> &cl) {
     }, pybind11::keep_alive<0, 1>())
     .def("__bool__", [](Block &range) {
         return !ranges::empty(range);
-        
     })
     .def("__len__", [](Block &range) {
         return range.size();

--- a/blockscipy/src/chain/input/input_properties_py.hpp
+++ b/blockscipy/src/chain/input/input_properties_py.hpp
@@ -1,0 +1,34 @@
+//
+//  input_properties_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/26/19.
+//
+
+#ifndef input_properties_py_h
+#define input_properties_py_h
+
+#include "method_tags.hpp"
+
+#include <blocksci/chain/block.hpp>
+
+struct AddInputMethods {
+    template <typename FuncApplication>
+    void operator()(FuncApplication func) {
+        using namespace blocksci;
+        func(property_tag, "value", &Input::getValue, "The value in base currency attached to this input");
+        func(property_tag, "address_type", &Input::getType, "The address type of the input");
+        func(property_tag, "sequence_num", &Input::sequenceNumber, "The sequence number of the input");
+        func(property_tag, "spent_tx_index", &Input::spentTxIndex, "The index of the transaction that this input spent");
+        func(property_tag, "spent_tx", &Input::getSpentTx, "The transaction that this input spent");
+        func(property_tag, "spent_output", &Input::getSpentOutput, "The output that this input spent");
+        func(property_tag, "age", &Input::age, "The number of blocks between the spent output and this input");
+        func(property_tag, "tx", &Input::transaction, "The transaction that contains this input");
+        func(property_tag, "block", &Input::block, "The block that contains this input");
+        func(property_tag, "index", &Input::inputIndex, "The index inside this transaction's inputs");
+        func(property_tag, "tx_index", &Input::txIndex, "The tx index of this input's transaction");
+        ;
+    }
+};
+
+#endif /* input_properties_py_h */

--- a/blockscipy/src/chain/input/input_proxy_py.cpp
+++ b/blockscipy/src/chain/input/input_proxy_py.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "input_proxy_py.hpp"
+#include "input_properties_py.hpp"
 #include "proxy_apply_py.hpp"
 #include "proxy/basic.hpp"
 #include "proxy/equality.hpp"
@@ -14,29 +15,17 @@
 #include "proxy/optional.hpp"
 #include "proxy/range.hpp"
 
-#include <blocksci/chain/block.hpp>
-#include <blocksci/cluster/cluster.hpp>
 
-
-struct AddInputMethods {
+struct AddInputProxyMethods {
     template <typename FuncApplication>
     void operator()(FuncApplication func) {
         using namespace blocksci;
+
         func(property_tag, "address", &Input::getAddress, "The address linked to this input");
-        func(property_tag, "value", &Input::getValue, "The value in base currency attached to this input");
-        func(property_tag, "address_type", &Input::getType, "The address type of the input");
-        func(property_tag, "sequence_num", &Input::sequenceNumber, "The sequence number of the input");
-        func(property_tag, "spent_tx_index", &Input::spentTxIndex, "The index of the transaction that this input spent");
-        func(property_tag, "spent_tx", &Input::getSpentTx, "The transaction that this input spent");
-        func(property_tag, "spent_output", &Input::getSpentOutput, "The output that this input spent");
-        func(property_tag, "age", &Input::age, "The number of blocks between the spent output and this input");
-        func(property_tag, "tx", &Input::transaction, "The transaction that contains this input");
-        func(property_tag, "block", &Input::block, "The block that contains this input");
-        func(property_tag, "index", &Input::inputIndex, "The index inside this transaction's inputs");
-        func(property_tag, "tx_index", &Input::txIndex, "The tx index of this input's transaction");
         ;
     }
 };
+
 
 void addInputProxyMethods(AllProxyClasses<blocksci::Input> &cls) {
     cls.applyToAll(AddProxyMethods{});
@@ -44,6 +33,7 @@ void addInputProxyMethods(AllProxyClasses<blocksci::Input> &cls) {
     addProxyOptionalMethods(cls.optional);
 
     applyMethodsToProxy(cls.base, AddInputMethods{});
+    applyMethodsToProxy(cls.base, AddInputProxyMethods{});
     addProxyEqualityMethods(cls.base);
     addProxyComparisonMethods(cls.base);
 }

--- a/blockscipy/src/chain/input/input_py.cpp
+++ b/blockscipy/src/chain/input/input_py.cpp
@@ -6,8 +6,10 @@
 //
 
 #include "input_py.hpp"
+#include "input_properties_py.hpp"
 #include "ranges_py.hpp"
 #include "caster_py.hpp"
+#include "self_apply_py.hpp"
 
 #include <blocksci/chain/access.hpp>
 #include <blocksci/chain/block.hpp>
@@ -19,6 +21,8 @@ namespace py = pybind11;
 using namespace blocksci;
 
 void init_input(py::class_<Input> &cl) {
+    applyMethodsToSelf(cl, AddInputMethods{});
+
     cl
     .def("__repr__", &Input::toString)
     .def(py::self == py::self)

--- a/blockscipy/src/chain/output/output_properties_py.hpp
+++ b/blockscipy/src/chain/output/output_properties_py.hpp
@@ -1,0 +1,35 @@
+//
+//  output_properties_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/26/19.
+//
+
+#ifndef output_properties_py_h
+#define output_properties_py_h
+
+#include "method_tags.hpp"
+
+#include <blocksci/chain/block.hpp>
+
+
+struct AddOutputMethods {
+    template <typename FuncApplication>
+    void operator()(FuncApplication func) {
+        using namespace blocksci;
+        func(property_tag, "value", &Output::getValue, "The value in base currency attached to this output");
+        func(property_tag, "address_type", &Output::getType, "The address type of the output");
+        func(property_tag, "is_spent", &Output::isSpent, "Returns whether this output has been spent");
+        func(property_tag, "spending_tx_index", &Output::getSpendingTxIndex, "Returns the index of the tranasction which spent this output or 0 if it is unspent");
+        func(property_tag, "spending_tx", &Output::getSpendingTx, "The transaction that spent this output or None if it is unspent");
+        func(property_tag, "spending_input", &Output::getSpendingInput, "The input that spent this output or None if it is unspent");
+        func(property_tag, "tx", &Output::transaction, "The transaction that contains this input");
+        func(property_tag, "block", &Output::block, "The block that contains this input");
+        func(property_tag, "index", &Output::outputIndex, "The output index inside this output's transaction");
+        func(property_tag, "tx_index", &Output::txIndex, "The tx index of this output's transaction");
+        ;
+    }
+};
+
+
+#endif /* output_properties_py_h */

--- a/blockscipy/src/chain/output/output_proxy_py.cpp
+++ b/blockscipy/src/chain/output/output_proxy_py.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "output_proxy_py.hpp"
+#include "output_properties_py.hpp"
 #include "proxy_apply_py.hpp"
 #include "proxy/basic.hpp"
 #include "proxy/equality.hpp"
@@ -14,34 +15,16 @@
 #include "proxy/optional.hpp"
 #include "proxy/range.hpp"
 
-#include <blocksci/chain/block.hpp>
-#include <blocksci/cluster/cluster.hpp>
-
-
-struct AddOutputMethods {
+struct AddOutputProxyMethods {
     template <typename FuncApplication>
     void operator()(FuncApplication func) {
         using namespace blocksci;
+        
         func(property_tag, "address", &Output::getAddress, "This address linked to this output");
-        func(property_tag, "value", &Output::getValue, "The value in base currency attached to this output");
-        func(property_tag, "address_type", &Output::getType, "The address type of the output");
-        func(property_tag, "is_spent", &Output::isSpent, "Returns whether this output has been spent");
-        func(property_tag, "spending_tx_index", &Output::getSpendingTxIndex, "Returns the index of the tranasction which spent this output or 0 if it is unspent");
-        func(property_tag, "spending_tx", &Output::getSpendingTx, "The transaction that spent this output or None if it is unspent");
-        func(property_tag, "spending_input", &Output::getSpendingInput, "The input that spent this output or None if it is unspent");
-        func(property_tag, "tx", &Output::transaction, "The transaction that contains this input");
-        func(property_tag, "block", &Output::block, "The block that contains this input");
-        func(property_tag, "index", &Output::outputIndex, "The output index inside this output's transaction");
-        func(property_tag, "tx_index", &Output::txIndex, "The tx index of this output's transaction");
         ;
     }
 };
 
-struct AddOutputProxyMethods {
-	void operator()(pybind11::class_<Proxy<blocksci::Output>> &cl) {
-		applyMethodsToProxy(cl, AddOutputMethods{});
-	}
-};
 
 void addOutputProxyMethods(AllProxyClasses<blocksci::Output> &cls) {
     cls.applyToAll(AddProxyMethods{});
@@ -49,6 +32,7 @@ void addOutputProxyMethods(AllProxyClasses<blocksci::Output> &cls) {
     addProxyOptionalMethods(cls.optional);
 
     applyMethodsToProxy(cls.base, AddOutputMethods{});
+    applyMethodsToProxy(cls.base, AddOutputProxyMethods{});
     addProxyEqualityMethods(cls.base);
     addProxyComparisonMethods(cls.base);
 }

--- a/blockscipy/src/chain/output/output_py.cpp
+++ b/blockscipy/src/chain/output/output_py.cpp
@@ -6,6 +6,8 @@
 //
 
 #include "output_py.hpp"
+#include "output_properties_py.hpp"
+#include "self_apply_py.hpp"
 #include "ranges_py.hpp"
 #include "caster_py.hpp"
 
@@ -19,6 +21,8 @@ namespace py = pybind11;
 using namespace blocksci;
 
 void init_output(py::class_<Output> &cl) {
+    applyMethodsToSelf(cl, AddOutputMethods{});
+
     cl
     .def("__repr__", &Output::toString)
     .def(py::self == py::self)

--- a/blockscipy/src/chain/tx/tx_properties_py.hpp
+++ b/blockscipy/src/chain/tx/tx_properties_py.hpp
@@ -1,0 +1,85 @@
+//
+//  tx_properties_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/26/19.
+//
+
+#ifndef tx_properties_py_h
+#define tx_properties_py_h
+
+#include "method_tags.hpp"
+
+#include <blocksci/chain/algorithms.hpp>
+#include <blocksci/chain/block.hpp>
+
+#include <pybind11/chrono.h>
+#include <pybind11/operators.h>
+
+struct AddTransactionMethods {
+    template <typename FuncApplication>
+    void operator()(FuncApplication func) {
+        using namespace blocksci;
+
+        func(property_tag, "output_count", &Transaction::outputCount, "The number of outputs this transaction has");
+        func(property_tag, "input_count", &Transaction::inputCount, "The number of inputs this transaction has");
+        func(property_tag, "size_bytes", &Transaction::totalSize, "The size of this transaction in bytes");
+        func(property_tag, "base_size", &Transaction::baseSize, "The size of the non-segwit data in bytes");
+        func(property_tag, "total_size", &Transaction::totalSize, "The size all transaction data in bytes");
+        func(property_tag, "virtual_size", &Transaction::virtualSize, "The weight of the transaction divided by 4");
+        func(property_tag, "weight", &Transaction::weight, "Three times the base size plus the total size");
+        func(property_tag, "locktime", &Transaction::locktime, "The locktime of this transasction");
+        func(property_tag, "version", &Transaction::getVersion, "The version of this transaction");
+        func(property_tag, "block_height", &Transaction::getBlockHeight, "The height of the block that this transaction was in");
+        func(property_tag, "block_time", +[](const Transaction &tx) -> std::chrono::system_clock::time_point {
+            return tx.block().getTime();
+        }, "The time that the block containing this transaction arrived");
+        func(property_tag, "observed_in_mempool", &Transaction::observedInMempool, "Returns whether this transaction was seen in the mempool by the recorder");
+        func(property_tag, "time_seen", &Transaction::getTimeSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
+        func(property_tag, "timestamp_seen", &Transaction::getTimestampSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
+        func(property_tag, "block", &Transaction::block, "The block that this transaction was in");
+        func(property_tag, "index", +[](const Transaction &tx) { return tx.txNum; }, "The internal index of this transaction");
+        func(property_tag, "hash", &Transaction::getHash, "The 256-bit hash of this transaction");
+        func(property_tag, "input_value", totalInputValue<Transaction &>, "The sum of the value of all of the inputs");
+        func(property_tag, "output_value", totalOutputValue<Transaction &>, "The sum of the value of all of the outputs");
+        func(property_tag, "fee", +[](const Transaction &tx) -> int64_t {
+            return fee(tx);
+        }, "The fee paid by this transaction");
+        func(method_tag, "fee_per_byte", +[](const Transaction &tx, const std::string &sizeMeasure) -> int64_t {
+            auto txFee = fee(tx);
+            if (sizeMeasure == "total") {
+                return txFee / tx.totalSize();
+            } else if (sizeMeasure == "base") {
+                return txFee / tx.baseSize();
+            } else if(sizeMeasure == "weight") {
+                return txFee / tx.weight();
+            } else if(sizeMeasure == "virtual") {
+                return txFee / tx.virtualSize();
+            } else {
+                throw std::invalid_argument{"Size measure must be one of total, base, weight, or virtual"};
+            }
+        }, "The (rounded) ratio of fee paid to size of this transaction (in byte). By default this uses virtual size, but passing total, base, weight, or virtual let's you choose a different size measure", pybind11::arg("size_measure") = "virtual");
+        func(method_tag, "fee_per_kbyte", +[](const Transaction &tx, const std::string &sizeMeasure) -> int64_t {
+            auto txFee = fee(tx);
+            if (sizeMeasure == "total") {
+                return txFee * 1000 / tx.totalSize();
+            } else if (sizeMeasure == "base") {
+                return txFee * 1000 / tx.baseSize();
+            } else if(sizeMeasure == "weight") {
+                return txFee * 1000 / tx.weight();
+            } else if(sizeMeasure == "virtual") {
+                return txFee * 1000 / tx.virtualSize();
+            } else {
+                throw std::invalid_argument{"Size measure must be one of total, base, weight, or virtual"};
+            }
+        }, "The (rounded) ratio of fee paid to size of this transaction (in kbyte). By default this uses virtual size, but passing total, base, weight, or virtual let's you choose a different size measure", pybind11::arg("size_measure") = "virtual");
+        func(property_tag, "op_return", +[](const Transaction &tx) -> ranges::optional<Output> {
+            return getOpReturn(tx);
+        }, "If this transaction included a null data address, return its output. Otherwise return None");
+        func(method_tag, "includes_output_of_type", includesOutputOfType, "Check whether the given transaction includes an output of the given address type", pybind11::arg("address_type"));
+        func(property_tag, "is_coinbase", &Transaction::isCoinbase, "Return's true if this transaction is a Coinbase transaction");
+    }
+};
+
+
+#endif /* tx_properties_py_h */

--- a/blockscipy/src/chain/tx/tx_proxy_py.cpp
+++ b/blockscipy/src/chain/tx/tx_proxy_py.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "tx_proxy_py.hpp"
+#include "tx_properties_py.hpp"
 #include "proxy_apply_py.hpp"
 #include "proxy/basic.hpp"
 #include "proxy/equality.hpp"
@@ -14,12 +15,7 @@
 #include "proxy/optional.hpp"
 #include "proxy/range.hpp"
 
-#include <blocksci/heuristics/change_address.hpp>
-#include <blocksci/chain/algorithms.hpp>
-#include <blocksci/chain/block.hpp>
-#include <blocksci/cluster/cluster.hpp>
-
-struct AddTransactionMethods {
+struct AddProxyTransactionMethods {
     template <typename FuncApplication>
     void operator()(FuncApplication func) {
         using namespace blocksci;
@@ -28,70 +24,7 @@ struct AddTransactionMethods {
         func(property_tag, "inputs", &Transaction::inputs, "A list of the inputs of the transaction"); // same as above
         func(property_tag, "outs", &Transaction::outputs, "A list of the outputs of the transaction"); // same as below
         func(property_tag, "outputs", &Transaction::outputs, "A list of the outputs of the transaction"); // same as above
-        func(property_tag, "output_count", &Transaction::outputCount, "The number of outputs this transaction has");
-        func(property_tag, "input_count", &Transaction::inputCount, "The number of inputs this transaction has");
-        func(property_tag, "size_bytes", &Transaction::totalSize, "The size of this transaction in bytes");
-        func(property_tag, "base_size", &Transaction::baseSize, "The size of the non-segwit data in bytes");
-        func(property_tag, "total_size", &Transaction::totalSize, "The size all transaction data in bytes");
-        func(property_tag, "virtual_size", &Transaction::virtualSize, "The weight of the transaction divided by 4");
-        func(property_tag, "weight", &Transaction::weight, "Three times the base size plus the total size");
-        func(property_tag, "locktime", &Transaction::locktime, "The locktime of this transasction");
-        func(property_tag, "version", &Transaction::getVersion, "The version of this transasction");
-        func(property_tag, "block_height", &Transaction::getBlockHeight, "The height of the block that this transaction was in");
-        func(property_tag, "block_time", +[](const Transaction &tx) -> std::chrono::system_clock::time_point {
-            return tx.block().getTime();
-        }, "The time that the block containing this transaction arrived");
-        func(property_tag, "observed_in_mempool", &Transaction::observedInMempool, "Returns whether this transaction was seen in the mempool by the recorder");
-        func(property_tag, "time_seen", &Transaction::getTimeSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
-        func(property_tag, "timestamp_seen", &Transaction::getTimestampSeen, "If recorded by the mempool recorder, the time that this transaction was first seen by your node");
-        func(property_tag, "block", &Transaction::block, "The block that this transaction was in");
-        func(property_tag, "index", +[](const Transaction &tx) { return tx.txNum; }, "The internal index of this transaction");
-        func(property_tag, "hash", &Transaction::getHash, "The 256-bit hash of this transaction");
-        func(property_tag, "input_value", totalInputValue<Transaction &>, "The sum of the value of all of the inputs");
-        func(property_tag, "output_value", totalOutputValue<Transaction &>, "The sum of the value of all of the outputs");
-        func(property_tag, "fee", +[](const Transaction &tx) -> int64_t {
-            return fee(tx);
-        }, "The fee paid by this transaction");
-        func(method_tag, "fee_per_byte", +[](const Transaction &tx, const std::string &sizeMeasure) -> int64_t {
-            auto txFee = fee(tx);
-            if (sizeMeasure == "total") {
-                return txFee / tx.totalSize();
-            } else if (sizeMeasure == "base") {
-                return txFee / tx.baseSize();
-            } else if(sizeMeasure == "weight") {
-                return txFee / tx.weight();
-            } else if(sizeMeasure == "virtual") {
-                return txFee / tx.virtualSize();
-            } else {
-                throw std::invalid_argument{"Size measure must be one of total, base, weight, or virtual"};
-            }
-        }, "The (rounded) ratio of fee paid to size of this transaction (in byte). By default this uses virtual size, but passing total, base, weight, or virtual let's you choose a different size measure", pybind11::arg("size_measure") = "virtual");
-        func(method_tag, "fee_per_kbyte", +[](const Transaction &tx, const std::string &sizeMeasure) -> int64_t {
-            auto txFee = fee(tx);
-            if (sizeMeasure == "total") {
-                return txFee * 1000 / tx.totalSize();
-            } else if (sizeMeasure == "base") {
-                return txFee * 1000 / tx.baseSize();
-            } else if(sizeMeasure == "weight") {
-                return txFee * 1000 / tx.weight();
-            } else if(sizeMeasure == "virtual") {
-                return txFee * 1000 / tx.virtualSize();
-            } else {
-                throw std::invalid_argument{"Size measure must be one of total, base, weight, or virtual"};
-            }
-        }, "The (rounded) ratio of fee paid to size of this transaction (in kbyte). By default this uses virtual size, but passing total, base, weight, or virtual let's you choose a different size measure", pybind11::arg("size_measure") = "virtual");
-        func(property_tag, "op_return", +[](const Transaction &tx) -> ranges::optional<Output> {
-            return getOpReturn(tx);
-        }, "If this transaction included a null data address, return its output. Otherwise return None");
-        func(method_tag, "includes_output_of_type", includesOutputOfType, "Check whether the given transaction includes an output of the given address type", pybind11::arg("address_type"));
-        func(property_tag, "is_coinbase", &Transaction::isCoinbase, "Return's true if this transaction is a Coinbase transaction");
     }
-};
-
-struct AddTxProxyMethods {
-	void operator()(pybind11::class_<Proxy<blocksci::Transaction>> &cl) {
-		applyMethodsToProxy(cl, AddTransactionMethods{});
-	}
 };
 
 void addTxProxyMethods(AllProxyClasses<blocksci::Transaction> &cls) {
@@ -100,6 +33,7 @@ void addTxProxyMethods(AllProxyClasses<blocksci::Transaction> &cls) {
     addProxyOptionalMethods(cls.optional);
 
     applyMethodsToProxy(cls.base, AddTransactionMethods{});
+    applyMethodsToProxy(cls.base, AddProxyTransactionMethods{});
     addProxyEqualityMethods(cls.base);
     addProxyComparisonMethods(cls.base);
 }

--- a/blockscipy/src/chain/tx/tx_py.cpp
+++ b/blockscipy/src/chain/tx/tx_py.cpp
@@ -7,20 +7,22 @@
 //
 
 #include "tx_py.hpp"
+#include "tx_properties_py.hpp"
 #include "ranges_py.hpp"
 #include "caster_py.hpp"
+#include "self_apply_py.hpp"
 
 #include <blocksci/chain/access.hpp>
 #include <blocksci/chain/blockchain.hpp>
-#include <blocksci/cluster/cluster.hpp>
-
-#include <pybind11/operators.h>
+#include <blocksci/chain/block.hpp>
 
 namespace py = pybind11;
 
 using namespace blocksci;
 
 void init_tx(py::class_<Transaction> &cl) {
+    applyMethodsToSelf(cl, AddTransactionMethods{});
+
     cl
     .def("__str__", &Transaction::toString)
     .def("__repr__", &Transaction::toString)

--- a/blockscipy/src/cluster/cluster/cluster_properties_py.hpp
+++ b/blockscipy/src/cluster/cluster/cluster_properties_py.hpp
@@ -1,0 +1,49 @@
+//
+//  cluster_properties_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/26/19.
+//
+
+#ifndef cluster_properties_py_h
+#define cluster_properties_py_h
+
+#include "method_tags.hpp"
+
+#include <blocksci/cluster/cluster.hpp>
+
+#include <pybind11/operators.h>
+
+
+struct AddClusterMethods {
+    template <typename FuncApplication>
+    void operator()(FuncApplication func) {
+        using namespace blocksci;
+
+        func(property_tag, "index", +[](const Cluster &cluster) { return cluster.clusterNum; }, "The internal identifier of the cluster");
+        func(method_tag, "tagged_addresses", &Cluster::taggedAddresses, "Given a dictionary of tags, return a range of TaggedAddress objects for any tagged addresses in the cluster", pybind11::arg("tagged_addresses"));
+        func(method_tag, "address_count", &Cluster::getSize, "The number of addresses in the cluster");
+        func(property_tag, "type_equiv_size", &Cluster::getTypeEquivSize, "The number of addresses in the cluster not counting type equivalent addresses");
+        func(method_tag, "balance", &Cluster::calculateBalance, "Calculates the balance held by this cluster at the height (Defaults to the full chain)", pybind11::arg("height") = -1);
+
+        func(method_tag, "out_txes_count", +[](Cluster &cluster) -> int64_t {
+            pybind11::print("Warning: `out_txes_count` is deprecated. Use `output_txes_count` instead.");
+            return cluster.getOutputTransactions().size();
+        }, "Return the number of transactions where an address in this cluster was used in an output");
+        func(method_tag, "output_txes_count", +[](Cluster &cluster) -> int64_t {
+            return cluster.getOutputTransactions().size();
+        }, "Return the number of transactions where an address in this cluster was used in an output");
+
+        func(method_tag, "in_txes_count", +[](Cluster &cluster) -> int64_t {
+            pybind11::print("Warning: `in_txes_count` is deprecated. Use `input_txes_count` instead.");
+            return cluster.getInputTransactions().size();
+        }, "Return the number of transactions where this cluster was an input");
+        func(method_tag, "input_txes_count", +[](Cluster &cluster) -> int64_t {
+            return cluster.getInputTransactions().size();
+        }, "Return the number of transactions where this cluster was an input");
+
+        func(method_tag, "count_of_type", &Cluster::countOfType, "Return the number of addresses of the given type in the cluster", pybind11::arg("address_type"));
+    }
+};
+
+#endif /* cluster_properties_py_h */

--- a/blockscipy/src/cluster/cluster/cluster_proxy_py.cpp
+++ b/blockscipy/src/cluster/cluster/cluster_proxy_py.cpp
@@ -7,40 +7,17 @@
 //
 
 #include "cluster_proxy_py.hpp"
+#include "cluster_properties_py.hpp"
 #include "proxy_apply_py.hpp"
 #include "proxy/basic.hpp"
 #include "proxy/equality.hpp"
 #include "proxy/optional.hpp"
 #include "proxy/range.hpp"
 
-#include <blocksci/cluster/cluster.hpp>
-
-struct AddClusterMethods {
+struct AddClusterProxyMethods {
     template <typename FuncApplication>
     void operator()(FuncApplication func) {
         using namespace blocksci;
-        func(property_tag, "index", +[](const Cluster &cluster) { return cluster.clusterNum; }, "The internal identifier of the cluster");
-        func(method_tag, "tagged_addresses", &Cluster::taggedAddresses, "Given a dictionary of tags, return a range of TaggedAddress objects for any tagged addresses in the cluster", pybind11::arg("tagged_addresses"));
-        func(method_tag, "address_count", &Cluster::getSize, "The number of addresses in the cluster");
-        func(property_tag, "type_equiv_size", &Cluster::getTypeEquivSize, "The number of addresses in the cluster not counting type equivalent addresses");
-        func(method_tag, "balance", &Cluster::calculateBalance, "Calculates the balance held by this cluster at the height (Defaults to the full chain)", pybind11::arg("height") = -1);
-
-        func(method_tag, "out_txes_count", +[](Cluster &cluster) -> int64_t {
-            pybind11::print("Warning: `out_txes_count` is deprecated. Use `output_txes_count` instead.");
-            return cluster.getOutputTransactions().size();
-        }, "Return the number of transactions where an address in this cluster was used in an output");
-        func(method_tag, "output_txes_count", +[](Cluster &cluster) -> int64_t {
-            return cluster.getOutputTransactions().size();
-        }, "Return the number of transactions where an address in this cluster was used in an output");
-
-        func(method_tag, "in_txes_count", +[](Cluster &cluster) -> int64_t {
-            pybind11::print("Warning: `in_txes_count` is deprecated. Use `input_txes_count` instead.");
-            return cluster.getInputTransactions().size();
-        }, "Return the number of transactions where this cluster was an input");
-        func(method_tag, "input_txes_count", +[](Cluster &cluster) -> int64_t {
-            return cluster.getInputTransactions().size();
-        }, "Return the number of transactions where this cluster was an input");
-
         func(method_tag, "outs", +[](Cluster &cluster) -> RawIterator<Output> {
             pybind11::print("Warning: `outs` is deprecated. Use `outputs` instead.");
             return cluster.getOutputs();
@@ -62,7 +39,6 @@ struct AddClusterMethods {
                 return address.getScript();
             })};
         }, "Get a iterable over all the addresses in the cluster");
-        func(method_tag, "count_of_type", &Cluster::countOfType, "Return the number of addresses of the given type in the cluster", pybind11::arg("address_type"));
     }
 };
 
@@ -73,5 +49,6 @@ void addClusterProxyMethods(AllProxyClasses<blocksci::Cluster> &cls) {
     setupRangesProxy(cls);
 
     applyMethodsToProxy(cls.base, AddClusterMethods{});
+    applyMethodsToProxy(cls.base, AddClusterProxyMethods{});
     addProxyEqualityMethods(cls.base);
 }

--- a/blockscipy/src/cluster/cluster/cluster_py.cpp
+++ b/blockscipy/src/cluster/cluster/cluster_py.cpp
@@ -7,16 +7,17 @@
 //
 
 #include "cluster_py.hpp"
+#include "cluster_properties_py.hpp"
 #include "ranges_py.hpp"
 #include "caster_py.hpp"
 #include "proxy_utils.hpp"
+#include "self_apply_py.hpp"
 
 #include <blocksci/cluster/cluster_manager.hpp>
 #include <blocksci/heuristics/change_address.hpp>
 
 #include <blocksci/chain/blockchain.hpp>
 #include <blocksci/chain/block.hpp>
-#include <blocksci/cluster/cluster.hpp>
 
 #include <range/v3/range_for.hpp>
 
@@ -77,8 +78,10 @@ void init_cluster_manager(pybind11::module &s) {
 }
 
 void init_cluster(py::class_<Cluster> &cl) {
+
+    applyMethodsToSelf(cl, AddClusterMethods{});
+
     cl
-    .def_readonly("cluster_num", &Cluster::clusterNum)
     .def("__len__", &Cluster::getSize)
     .def("__hash__", [] (const Cluster &cluster) {
         return cluster.clusterNum;

--- a/blockscipy/src/scripts/equiv_address/equiv_address_py.cpp
+++ b/blockscipy/src/scripts/equiv_address/equiv_address_py.cpp
@@ -36,10 +36,7 @@ void init_equiv_address(py::class_<EquivAddress> &cl) {
     .def("in_txes", [](EquivAddress &address) {
         pybind11::print("Warning: `in_txes` is deprecated. Use `input_txes` instead.");
         return address.getInputTransactions();
-    }, "Returns a list of all transaction where these equivalent addresses were an input")
-    .def_property_readonly("addresses", +[](EquivAddress &address) -> std::unordered_set<Address> {
-        return {address.begin(), address.end()};
-    }, "Returns an iterator over the addresses that make up this equivalent address");
+    }, "Returns a list of all transaction where these equivalent addresses were an input");
     ;
 }
 

--- a/blockscipy/src/self_apply_py.hpp
+++ b/blockscipy/src/self_apply_py.hpp
@@ -1,0 +1,41 @@
+//
+//  self_apply_py.hpp
+//  blockscipy
+//
+//  Created by Malte Moeser on 8/23/19.
+//
+
+#ifndef self_apply_py_h
+#define self_apply_py_h
+
+#include "func_converter.hpp"
+#include "method_tags.hpp"
+#include "blocksci_type_converter.hpp"
+
+#include <pybind11/pybind11.h>
+
+
+template <typename Class>
+struct ApplyMethodsToSelfImpl {
+    using P = typename Class::type;
+    Class &cl;
+
+    ApplyMethodsToSelfImpl(Class &cl_) : cl(cl_) {}
+
+    template <typename F, typename... Extra>
+    void operator()(method_tag_type, const std::string &propertyName, F func, const std::string &description, Extra && ...extra) {
+        cl.def(strdup(propertyName.c_str()), func, std::forward<Extra>(extra)..., strdup(description.c_str()));
+    }
+
+    template <typename F, typename... Extra>
+    void operator()(property_tag_type, const std::string &propertyName, F func, const std::string &description, Extra && ...extra) {
+        cl.def_property_readonly(strdup(propertyName.c_str()), pybind11::cpp_function(std::move(func), pybind11::return_value_policy::reference_internal), strdup(description.c_str()));
+    }
+};
+
+template <typename Class, typename Applier>
+void applyMethodsToSelf(Class &cl, Applier applier) {
+    applier(ApplyMethodsToSelfImpl<Class>{cl});
+}
+
+#endif /* self_apply_py_h */

--- a/test/blockscipy/test_chain.py
+++ b/test/blockscipy/test_chain.py
@@ -87,7 +87,20 @@ def test_filter_blocks(chain):
     assert blocks1 == blocks2
 
 
+def test_filter_blocks_legacy(chain):
+    blocks1 = [b for b in chain.blocks if b.height % 3 == 0]
+    blocks2 = chain.filter_blocks_legacy(lambda b: b.height % 3 == 0)
+
+    assert blocks1 == blocks2
+
+
 def test_filter_txes(chain):
     txs1 = [tx for block in chain for tx in block if tx.block.height % 3 == 0]
     txs2 = chain.filter_txes(lambda tx: tx.block.height % 3 == 0)
+    assert txs1 == txs2
+
+
+def test_filter_txes_legacy(chain):
+    txs1 = [tx for block in chain for tx in block if tx.block.height % 3 == 0]
+    txs2 = chain.filter_txes_legacy(lambda tx: tx.block.height % 3 == 0)
     assert txs1 == txs2

--- a/test/blockscipy/test_clustering.py
+++ b/test/blockscipy/test_clustering.py
@@ -73,7 +73,6 @@ def test_clustering_no_change(chain, json_data, regtest, tmpdir_factory):
         in cluster.addresses.to_list()
     )
 
-    assert cluster.cluster_num >= 0
     assert cluster.index >= 0
 
     print(cluster.addresses.to_list(), file=regtest)
@@ -139,7 +138,6 @@ def test_clustering_with_change(chain, json_data, tmpdir_factory, regtest):
             in cluster.addresses.to_list()
         )
 
-        assert cluster.cluster_num >= 0
         assert cluster.index >= 0
 
         cluster_regtest(chain, json_data, regtest, cm)


### PR DESCRIPTION
Implemented:

- [x] Single-value properties returned by chain objects (block, tx, input, output), except for addresses
- [x] Single-value properties returned by cluster objects
- [ ] Single-value properties returned by address objects
- [ ] Returning address objects
- [ ] Returning ranges/iterators