### PR TITLE
fix: CMake: fix build for gcc >= 8.0

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -33,7 +33,7 @@ target_include_directories(secp256k1 INTERFACE ${install_dir}/include)
 target_link_libraries(secp256k1 INTERFACE ${install_dir}/lib/libsecp256k1.a)
 
 set(saved_flags "${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wno-error=class-memaccess -Wno-error=stringop-truncation")
 set(WITH_TESTS OFF)
 set(WITH_TOOLS OFF)
 set(WITH_GFLAGS OFF)


### PR DESCRIPTION
GCC version 8.0 introduced new warnings which cause the rocksdb submodule build to fail.

This is a workaround for issue #320 for the v0.5 release branch where the dependencies are not intended to be updated anymore.