### PR TITLE
fix: CMake: remove linking with sparsehash

### DIFF
--- a/tools/parser/CMakeLists.txt
+++ b/tools/parser/CMakeLists.txt
@@ -27,6 +27,5 @@ target_link_libraries( blocksci_parser clipp)
 target_link_libraries( blocksci_parser blocksci)
 target_link_libraries( blocksci_parser Boost::serialization Boost::iostreams Boost::filesystem)
 target_link_libraries( blocksci_parser secp256k1)
-target_link_libraries( blocksci_parser sparsehash)
 
 install(TARGETS blocksci_parser DESTINATION bin)


### PR DESCRIPTION
sparsehash is a [header-only library](https://packages.debian.org/buster/all/libsparsehash-dev/filelist) and does not require any sorts of linking. In the contrary, without this patch the build fails.