### PR TITLE
chore: remove rollback code

### DIFF
--- a/src/internal/address_index.hpp
+++ b/src/internal/address_index.hpp
@@ -108,8 +108,6 @@ namespace blocksci {
 
         /** Compact the underlying RocksDB database */
         void compactDB();
-        
-        void rollback(uint32_t txNum);
     };
 }
 

--- a/src/internal/hash_index.hpp
+++ b/src/internal/hash_index.hpp
@@ -176,8 +176,6 @@ namespace blocksci {
         /** Add a mapping from tx hash to tx number to the hash index for all given rows */
         void addTxes(std::vector<std::pair<uint256, uint32_t>> rows);
         
-        void rollback(uint32_t txCount, const std::array<uint32_t, DedupAddressType::size> &scriptCounts);
-        
         ranges::any_view<std::pair<MemoryView, MemoryView>> getRawAddressRange(AddressType::Enum type);
         
         template<AddressType::Enum type>

--- a/tools/parser/address_state.cpp
+++ b/tools/parser/address_state.cpp
@@ -66,17 +66,6 @@ uint32_t AddressState::getNewAddressIndex(blocksci::DedupAddressType::Enum type)
     return scriptNum;
 }
 
-void AddressState::rollback(const blocksci::State &state) {
-    blocksci::for_each(multiAddressMaps, [&](auto &multiAddressMap) {
-        for (auto multiAddressIt = multiAddressMap.begin(); multiAddressIt != multiAddressMap.end(); ++multiAddressIt) {
-            auto count = state.scriptCounts[static_cast<size_t>(multiAddressMap.type)];
-            if (multiAddressIt->second >= count) {
-                multiAddressMap.erase(multiAddressIt);
-            }
-        }
-    });
-}
-
 void AddressState::reset(const blocksci::State &state) {
     reloadBloomFilters();
     scriptIndexes.clear();

--- a/tools/parser/address_state.hpp
+++ b/tools/parser/address_state.hpp
@@ -187,9 +187,6 @@ public:
     
     uint32_t getNewAddressIndex(blocksci::DedupAddressType::Enum type);
     
-    // Called before reseting index
-    void rollback(const blocksci::State &state);
-    
     // Called after resetting index
     void reset(const blocksci::State &state);
 };

--- a/tools/parser/address_writer.cpp
+++ b/tools/parser/address_writer.cpp
@@ -124,10 +124,3 @@ void AddressWriter::serializeInputImp(const ScriptInput<AddressType::WITNESS_UNK
     data.add(input.data.script.begin(), input.data.script.end());
     file.write<1>(input.scriptNum - 1, data);
 }
-
-void AddressWriter::rollback(const blocksci::State &state) {
-    blocksci::for_each(blocksci::DedupAddressType::all(), [&](auto tag) {
-        auto &file = std::get<ScriptFile<tag()>>(scriptFiles);
-        file.truncate(state.scriptCounts[static_cast<size_t>(tag)]);
-    });
-}

--- a/tools/parser/address_writer.hpp
+++ b/tools/parser/address_writer.hpp
@@ -36,44 +36,44 @@ struct ScriptFile : public ScriptFileType_t<type> {
 
 class AddressWriter {
     using ScriptFilesTuple = blocksci::to_dedup_address_tuple_t<ScriptFile>;
-    
+
     ScriptFilesTuple scriptFiles;
-    
+
     template<blocksci::AddressType::Enum type>
     void serializeInputImp(const ScriptInput<type> &, ScriptFile<dedupType(type)> &) {}
-    
+
     void serializeInputImp(const ScriptInput<blocksci::AddressType::PUBKEYHASH> &input, ScriptFile<blocksci::DedupAddressType::PUBKEY> &file);
     void serializeInputImp(const ScriptInput<blocksci::AddressType::WITNESS_PUBKEYHASH> &input, ScriptFile<blocksci::DedupAddressType::PUBKEY> &file);
     void serializeInputImp(const ScriptInput<blocksci::AddressType::SCRIPTHASH> &input, ScriptFile<blocksci::DedupAddressType::SCRIPTHASH> &file);
     void serializeInputImp(const ScriptInput<blocksci::AddressType::WITNESS_SCRIPTHASH> &input, ScriptFile<blocksci::DedupAddressType::SCRIPTHASH> &file);
     void serializeInputImp(const ScriptInput<blocksci::AddressType::NONSTANDARD> &input, ScriptFile<blocksci::DedupAddressType::NONSTANDARD> &file);
     void serializeInputImp(const ScriptInput<blocksci::AddressType::WITNESS_UNKNOWN> &input, ScriptFile<blocksci::DedupAddressType::WITNESS_UNKNOWN> &file);
-    
+
     template<blocksci::AddressType::Enum type>
     void serializeOutputImp(const ScriptOutput<type> &output, ScriptFile<dedupType(type)> &file, bool topLevel) {
         auto data = file[output.scriptNum - 1];
         data->saw(type, topLevel);
     }
-    
+
     void serializeOutputImp(const ScriptOutput<blocksci::AddressType::PUBKEY> &output, ScriptFile<blocksci::DedupAddressType::PUBKEY> &file, bool topLevel);
     void serializeOutputImp(const ScriptOutput<blocksci::AddressType::MULTISIG_PUBKEY> &output, ScriptFile<blocksci::DedupAddressType::PUBKEY> &file, bool topLevel);
     void serializeOutputImp(const ScriptOutput<blocksci::AddressType::WITNESS_SCRIPTHASH> &output, ScriptFile<blocksci::DedupAddressType::SCRIPTHASH> &file, bool topLevel);
     void serializeOutputImp(const ScriptOutput<blocksci::AddressType::NONSTANDARD> &output, ScriptFile<blocksci::DedupAddressType::NONSTANDARD> &file, bool topLevel);
     void serializeOutputImp(const ScriptOutput<blocksci::AddressType::WITNESS_UNKNOWN> &output, ScriptFile<blocksci::DedupAddressType::WITNESS_UNKNOWN> &file, bool topLevel);
-    
+
     template<blocksci::AddressType::Enum type>
     void serializeWrappedScript(const ScriptInputData<type> &, uint32_t, uint32_t) {}
-    
+
     void serializeWrappedScript(const ScriptInputData<blocksci::AddressType::Enum::SCRIPTHASH> &input, uint32_t txNum, uint32_t outputTxNum);
     void serializeWrappedScript(const ScriptInputData<blocksci::AddressType::Enum::WITNESS_SCRIPTHASH> &input, uint32_t txNum, uint32_t outputTxNum);
-    
+
 public:
-    
+
     template <blocksci::DedupAddressType::Enum type>
     ScriptFile<type> &getFile() {
         return std::get<ScriptFile<type>>(scriptFiles);
     }
-    
+
     template <blocksci::DedupAddressType::Enum type>
     const ScriptFile<type> &getFile() const {
         return std::get<ScriptFile<type>>(scriptFiles);
@@ -101,7 +101,7 @@ public:
         });
         return file.size();
     }
-    
+
     template<blocksci::AddressType::Enum type>
     void serializeExistingOutput(const ScriptOutput<type> &output, bool topLevel) {
         assert(!output.isNew);
@@ -138,15 +138,13 @@ public:
             serializeInputImp(input, file);
         }
     }
-    
-    void rollback(const blocksci::State &state);
-    
+
     blocksci::OffsetType serializeNewOutput(const AnyScriptOutput &output, uint32_t txNum, bool topLevel);
     void serializeExistingOutput(const AnyScriptOutput &output, bool topLevel);
-    
+
     void serializeInput(const AnyScriptInput &input, uint32_t txNum, uint32_t outputTxNum);
     void serializeWrappedScript(const AnyScriptInput &input, uint32_t txNum, uint32_t outputTxNum);
-    
+
     AddressWriter(const ParserConfigurationBase &config);
 };
 


### PR DESCRIPTION
Removes the rollback code from the parser, which hasn't been maintained and (as far as I know) doesn't work properly. We may add this back in the future, but for now I think it's better to replace it with an error when there's a reorganization.