### PR TITLE
fix: parse full chain index when maxBlockNum=0

### DIFF
--- a/tools/parser/chain_index.cpp
+++ b/tools/parser/chain_index.cpp
@@ -194,7 +194,7 @@ void ChainIndex<RPCTag>::update(const ConfigType &config, blocksci::BlockHeight 
         
         
         auto maxBlockHeight = static_cast<blocksci::BlockHeight>(bapi.getblockcount());
-        if (blockHeight < 0) {
+        if (blockHeight <= 0) {
             blockHeight = maxBlockHeight + blockHeight;
         }
         if (blockHeight > maxBlockHeight) {


### PR DESCRIPTION
Makes behavior consistent with the disk-based parser, i.e. to parse the full chain up to the maximum height when setting `maxBlockNum` to `0`