### PR TITLE
fix: inconsistent txFirstSpend 

### DIFF
--- a/tools/parser/address_writer.hpp
+++ b/tools/parser/address_writer.hpp
@@ -122,14 +122,19 @@ public:
         /** Default value of ScriptDataBase.txFirstSpent is (std::numeric_limits<uint32_t>::max()) */
         bool isFirstSpend = data->txFirstSpent == std::numeric_limits<uint32_t>::max();
 
+        /** Can occur when a wrapped input is serialized before the top-level input */
+        bool isNewerFirstSpend = txNum < data->txFirstSpent;
+
         /** Default value of ScriptDataBase.txFirstSeen is the txNum of the transaction that contained the script */
         bool isNewerFirstSeen = outputTxNum < data->txFirstSeen;
 
         if (isNewerFirstSeen) {
             data->txFirstSeen = outputTxNum;
         }
-        if (isFirstSpend) {
+        if (isNewerFirstSpend) {
             data->txFirstSpent = txNum;
+        }
+        if (isFirstSpend) {
             serializeInputImp(input, file);
         }
     }


### PR DESCRIPTION
Fixes a rare situation where, due to the parallel processing of transactions, it can happen that an input script is serialized as a wrapped script in a later transaction before it is serialized as a normal input script in a previous transaction. This is a simpler fix than moving the input processing of wrapped scripts to the last stage of the processing pipeline.

I'll double-check this with the new integrity check tool one more time before merging.

(shouldn't have #383, but made it easier for now to create the PR)