### PR TITLE
deps: upgrade pybind11 to v2.5.0

### DIFF
--- a/blockscipy/src/python_range_conversion.hpp
+++ b/blockscipy/src/python_range_conversion.hpp
@@ -20,13 +20,13 @@
 namespace pybind11 { namespace detail {
     template <>
     struct npy_format_descriptor<NumpyDatetime> { 
-        static PYBIND11_DESCR name() { return _("datetime64[ns]"); }
+        static constexpr auto name = _("datetime64[ns]");
         static pybind11::dtype dtype() { return pybind11::dtype(std::string("datetime64[ns]")); }
     };
 
     template <>
     struct npy_format_descriptor<NumpyBool> { 
-        static PYBIND11_DESCR name() { return _("bool"); }
+        static constexpr auto name = _("bool");
         static pybind11::dtype dtype() { return pybind11::dtype(std::string("bool")); }
     };
 }}


### PR DESCRIPTION
This doesn't affect the parser/C++ interface, only the python interface.

- [x] Performance comparison regtest testchain: https://gist.github.com/maltemoeser/79526a7148f06ae30830ca0bdab055df
- [x] Performance comparison BTC with 400k blocks: https://gist.github.com/maltemoeser/d71d501263885a489f69f5f74c789fab

Looks like there could be a very minor performance degradation, but nothing significant and results vary between runs.