### PR TITLE
deps: update mio dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/USCiLab/cereal
 [submodule "external/mio"]
 	path = external/mio
-	url = https://github.com/hkalodner/mio
+	url = https://github.com/mandreyel/mio
 [submodule "external/filesystem"]
 	path = external/filesystem
 	url = https://github.com/hkalodner/filesystem


### PR DESCRIPTION
Uses original repository instead of Harry’s fork

Required checks:
- [x] parser integrity check: [gist](https://gist.github.com/maltemoeser/a89d2c512e6c61c8ceb9897bc581b377)
- [ ] C++ performance comparison